### PR TITLE
Improved units for "parse_summary"

### DIFF
--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -33,6 +33,10 @@ def parse_summary(abs_log_summary_path):
             continue
         
         v = (v*unit).to_compact()
+
+        if v.u == ureg.us:
+            v.ito(ureg.ms) # Keep everything in milliseconds
+
         rounded = Quantity(round(v.m, 3), v.u)
         beautified_summary[k] = str(rounded) + "s" if rounded.m != 1 else ""
     

--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -37,8 +37,9 @@ def parse_summary(abs_log_summary_path):
         if v.u == ureg.us:
             v.ito(ureg.ms) # Keep everything in milliseconds
 
-        rounded = Quantity(round(v.m, 3), v.u)
-        beautified_summary[k] = str(rounded) + "s" if rounded.m != 1 else ""
+        unit_suffix = f"{v.u}{'s' if v.m != 1 else ''}"
+
+        beautified_summary[k] = f"{v.m :<.3f} {unit_suffix}"
     
     return beautified_summary
 

--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from function_access import to_num_or_not_to_num
-from pint import Quantity, UnitRegistry
+from pint import UnitRegistry
 
 
 def parse_summary(abs_log_summary_path):

--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -2,6 +2,7 @@
 
 from function_access import to_num_or_not_to_num
 
+
 def parse_summary(abs_log_summary_path):
 
     parsed_summary = {}
@@ -47,7 +48,7 @@ def unpack_accuracy_log(raw_accuracy_log):
     return readable_accuracy_log
 
 
-def guess_command(tags, framework, loadgen_scenario, loadgen_mode, model_name, loadgen_dataset_size, loadgen_buffer_size, loadgen_compiance_test = None, loadgen_target_qps = None, loadgen_target_latency=None, loadgen_multistreamness=None, sut_name = None):
+def guess_command(tags, framework, loadgen_scenario, loadgen_mode, model_name, loadgen_dataset_size, loadgen_buffer_size, loadgen_compliance_test = None, loadgen_target_qps = None, loadgen_target_latency=None, loadgen_multistreamness=None, sut_name = None):
 
     terms_list = [] + tags
     terms_list.append( f"framework={framework}" )
@@ -56,10 +57,10 @@ def guess_command(tags, framework, loadgen_scenario, loadgen_mode, model_name, l
     terms_list.append( f"model_name={model_name}" )
     terms_list.append( f"loadgen_dataset_size={loadgen_dataset_size}" )
     terms_list.append( f"loadgen_buffer_size={loadgen_buffer_size}" )
-    if loadgen_compiance_test is None:
-        terms_list.append( f"loadgen_compiance_test-" )
+    if loadgen_compliance_test is None:
+        terms_list.append( "loadgen_compliance_test-" )
     else:
-        terms_list.append( f"loadgen_compiance_test={loadgen_compiance_test}" )
+        terms_list.append( f"loadgen_compliance_test={loadgen_compliance_test}" )
     if sut_name is not None:
       terms_list.append( f"sut_name={sut_name}" )
 

--- a/base_loadgen_experiment/data_axs.json
+++ b/base_loadgen_experiment/data_axs.json
@@ -1,4 +1,11 @@
 {
+    "better_units_query": [ "python_package", "package_name=pint", ["desired_python_version", ["^", "kernel_python_major_dot_minor"]] ],
+    "_BEFORE_CODE_LOADING": [ "^^", "execute", [[
+        [ "get_kernel" ],
+        [ "byquery", [[ "^^", "get", "better_units_query" ]] ],
+        [ "use" ]
+    ]]],
+
     "rel_log_summary_path": "mlperf_log_summary.txt",
     "abs_log_summary_path": [ "^^", "get_path_from", "rel_log_summary_path" ],
 


### PR DESCRIPTION
I've changed how "parse_summary" prints the summary. It now compresses the value to a sensible unit, before rounding it down and then printing it.

Example:
```
{'SUT_name': 'KILT_SERVER', 'Scenario': 'Server', 'Mode': 'PerformanceOnly', 'Scheduled_samples_per_second': 491.97, 'Result_is': 'VALID', 'Performance_constraints_satisfied': 'Yes', 'Min_duration_satisfied': 'Yes', 'Min_queries_satisfied': 'Yes', 'Early_stopping_satisfied': 'Yes', 'Early_Stopping_Result': '', 'Completed_samples_per_second': 491.93, 'Min_latency': '643.11 microseconds', 'Max_latency': '1.642 milliseconds', 'Mean_latency': '799.823 microseconds', '50.00_percentile_latency': '775.883 microseconds', '90.00_percentile_latency': '906.944 microseconds', '95.00_percentile_latency': '1.03 milliseconds', '97.00_percentile_latency': '1.075 milliseconds', '99.00_percentile_latency': '1.169 milliseconds', '99.90_percentile_latency': '1.444 milliseconds', 'samples_per_query': 1, 'target_qps': 500, 'target_latency': '15.0 milliseconds', 'max_async_queries': 0, 'min_duration': '10.0 seconds', 'max_duration': '0 milliseconds', 'min_query_count': 100, 'max_query_count': 0, 'qsl_rng_seed': 13281865557512327830, 'sample_index_rng_seed': 198141574272810017, 'schedule_rng_seed': 7575108116881280410, 'accuracy_log_rng_seed': 0, 'accuracy_log_probability': 0, 'accuracy_log_sampling_target': 0, 'print_timestamps': 0, 'performance_issue_unique': 0, 'performance_issue_same': 0, 'performance_issue_same_index': 0, 'performance_sample_count': 1024}
```