### PR TITLE
Remove additional mixtral accuracy ranges checks.

### DIFF
--- a/base_mixtral_loadgen_experiment/data_axs.json
+++ b/base_mixtral_loadgen_experiment/data_axs.json
@@ -81,6 +81,6 @@
     "gen_tok_len": [ "^^" , "dig","accuracy_dict.gen_tok_len" ],
     "tokens_per_sample": [ "^^" , "dig","accuracy_dict.tokens_per_sample" ],
 
-    "accuracy_range_dict": { "rouge1": [ 45.036189, null ], "rouge2": [ 23.050071, null ], "rougeL": [ 30.057885, null], "rougeLsum":[ null, null ], "gsm8k": [ 73.0422, null ], "mbxp": [ 59.5188, null ], "gen_len": [ null, null ], "gen_num": [ null, null ], "gen_tok_len": [ null, null ], "tokens_per_sample": [ 131.31, 160.49 ] }
+    "accuracy_range_dict": { "rouge1": [ 45.036189, null ], "rouge2": [ 23.050071, null ], "rougeL": [ 30.057885, null], "gsm8k": [ 73.0422, null ], "mbxp": [ 59.5188, null ], "tokens_per_sample": [ 131.31, 160.49 ] }
 
 }


### PR DESCRIPTION
Removed :
1. rougeLsum
2. gen_len
3. gen_num
4. gen_tok_len