### PR TITLE
Performance summary accounting for the case of LLM benchmarks

### DIFF
--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -157,9 +157,9 @@ def parse_performance(beautified_summary, latency_cutoff_ratio, early_stopping_o
             if key_name == "latency_cutoff_ratio":
                 formatted_performance_metrics.append('{}={:.2f}'.format(key_name, latency_cutoff_ratio))
             elif key_name == "cutoff_ratio_ttft":
-                formatted_performance_metrics.append('{}={}'.format(key_name, latency_cutoff_ratio_ttft))
+                formatted_performance_metrics.append('{}={:.2f}'.format(key_name, latency_cutoff_ratio_ttft))
             elif key_name == "cutoff_ratio_tpot":
-                formatted_performance_metrics.append('{}={}'.format(key_name, latency_cutoff_ratio_tpot))
+                formatted_performance_metrics.append('{}={:.2f}'.format(key_name, latency_cutoff_ratio_tpot))
             elif key_name == "early_stopping_overhead":
                 formatted_performance_metrics.append('{}={:.2f}{}'.format(key_name, early_stopping_overhead, "%"))
             else:

--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -22,7 +22,7 @@ def beautify_summary(parsed_summary):
 
     ureg = UnitRegistry()
 
-    linked_keys = ["latency", "Early_stopping_9", "duration"]
+    linked_keys = ["latency", "Early_stopping_9", "duration", "time_to_output_token"]
 
     beautified_summary = {}
     kv_with_units = {}
@@ -65,12 +65,12 @@ def beautify_summary(parsed_summary):
     
     return beautified_summary
 
-def calc_latency_cutoff_ratio(beautified_summary, latency, target_latency):
+def calc_latency_cutoff_ratio(parsed_summary, latency, target_latency):
 
-    scenario = beautified_summary["Scenario"]
+    scenario = parsed_summary["Scenario"]
     if scenario == "Server":
-        if target_latency in beautified_summary.keys():
-            return beautified_summary[latency]/beautified_summary[target_latency]
+        if target_latency in parsed_summary:
+            return parsed_summary[latency]/parsed_summary[target_latency]
 
 def calc_early_stopping_overhead(parsed_summary):
 
@@ -83,7 +83,7 @@ def calc_early_stopping_overhead(parsed_summary):
 
 
 #returns list of formatted performance metrics (as strings) for given experiment  
-def parse_performance(beautified_summary, early_stopping_overhead, scenario_performance_map, raw=False):
+def parse_performance(parsed_summary, beautified_summary, early_stopping_overhead, scenario_performance_map, raw=False):
 
     scenario = beautified_summary["Scenario"]
     validity = beautified_summary["Result_is"]
@@ -91,17 +91,17 @@ def parse_performance(beautified_summary, early_stopping_overhead, scenario_perf
     if raw and validity == "INVALID":
         return None  
 
-    performance_metrics = scenario_performance_map[scenario][validity] 
+    performance_metrics = scenario_performance_map[scenario]
     formatted_performance_metrics = ['{}'.format(validity)] # set first element 
 
     for key_name in performance_metrics:
 
         if key_name == "latency_cutoff_ratio":
-            fmt, value = '{}={:.2f}', calc_latency_cutoff_ratio(beautified_summary, "99.00_percentile_latency", "target_latency")
+            fmt, value = '{}={:.2f}', calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_latency_ns", "target_latency_ns")
         elif key_name == "cutoff_ratio_ttft":
-            fmt, value = '{}={:.2f}', calc_latency_cutoff_ratio(beautified_summary, "99.00_percentile_first_token_latency", "ttft_latency")
+            fmt, value = '{}={:.2f}', calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_first_token_latency_ns", "ttft_latency_ns")
         elif key_name == "cutoff_ratio_tpot":
-            fmt, value = '{}={:.2f}', calc_latency_cutoff_ratio(beautified_summary, "99.00_percentile_time_to_output_token", "tpot_latency")
+            fmt, value = '{}={:.2f}', calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_time_to_output_token_ns", "tpot_latency_ns")
         elif key_name == "early_stopping_overhead":
             fmt, value = '{}={:.2f}%', early_stopping_overhead
         elif key_name in beautified_summary:

--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -72,51 +72,6 @@ def calc_latency_cutoff_ratio(parsed_summary, latency, target_latency):
         if target_latency in parsed_summary.keys():
             return parsed_summary[latency]/parsed_summary[target_latency]
 
-latency_classic = "99.00_percentile_latency_ns"
-latency_ttft = "99.00_percentile_first_token_latency_ns"
-latency_tpot = "99.00_percentile_time_to_output_token_ns"
-
-target_latency_classic = "target_latency_ns"
-target_latency_ttft = "ttft_latency_ns"
-target_latency_tpot = "tpot_latency_ns"
-
-latency_cutoff_ratio = calc_latency_cutoff_ratio(parsed_summary, latency_classic, target_latency_classic)
-latency_cutoff_ratio_ttft = calc_latency_cutoff_ratio(parsed_summary, latency_ttft, target_latency_ttft)
-latency_cutoff_ratio_tpot = calc_latency_cutoff_ratio(parsed_summary, latency_tpot, target_latency_tpot)
-
-# def calc_latency_cutoff_ratio(parsed_summary):
-    
-#     scenario = parsed_summary["Scenario"]
-#     if scenario == "Server":
-#         if "target_latency_ns" in parsed_summary.keys():
-#             latency_cutoff_ratio = parsed_summary["99.00_percentile_latency_ns"]/parsed_summary["target_latency_ns"]
-#         else:
-#             latency_cutoff_ratio = "None"
-
-#     return latency_cutoff_ratio
-
-# def calc_latency_cutoff_ratio_ttft(parsed_summary):
-
-#     scenario = parsed_summary["Scenario"]
-#     if scenario == "Server":
-#         if "ttft_latency_ns" in parsed_summary.keys():
-#             latency_cutoff_ratio_ttft = parsed_summary["99.00_percentile_first_token_latency_ns"]/parsed_summary["ttft_latency_ns"]
-#         else:
-#             latency_cutoff_ratio_ttft = "None"
-
-#     return latency_cutoff_ratio_ttft
-
-# def calc_latency_cutoff_ratio_tpot(parsed_summary):
-
-#     scenario = parsed_summary["Scenario"]
-#     if scenario == "Server":
-#         if "tpot_latency_ns" in parsed_summary.keys():
-#             latency_cutoff_ratio_tpot = parsed_summary["99.00_percentile_time_to_output_token_ns"]/parsed_summary["tpot_latency_ns"]
-#         else:
-#             latency_cutoff_ratio_tpot = "None"
-
-#     return latency_cutoff_ratio_tpot
-
 def calc_early_stopping_overhead(parsed_summary):
 
     scenario = parsed_summary["Scenario"]
@@ -143,11 +98,11 @@ def parse_performance(beautified_summary, latency_cutoff_ratio, early_stopping_o
 
         if raw:
             if key_name == "latency_cutoff_ratio":
-                formatted_performance_metrics.append(latency_cutoff_ratio)
+                formatted_performance_metrics.append(calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_latency_ns", "target_latency_ns"))
             elif key_name == "cutoff_ratio_ttft":
-                formatted_performance_metrics.append(latency_cutoff_ratio_ttft)
+                formatted_performance_metrics.append(calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_first_token_latency_ns", "ttft_latency_ns"))
             elif key_name == "cutoff_ratio_tpot":
-                formatted_performance_metrics.append(latency_cutoff_ratio_tpot)
+                formatted_performance_metrics.append(calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_time_to_output_token_ns", "tpot_latency_ns"))
             elif key_name == "early_stopping_overhead":
                 formatted_performance_metrics.append(early_stopping_overhead)
             else:
@@ -155,11 +110,11 @@ def parse_performance(beautified_summary, latency_cutoff_ratio, early_stopping_o
                
         else: #no need for multiplier, formatting, units in scenario_performance_map - the beautify_summary function does all of this already 
             if key_name == "latency_cutoff_ratio":
-                formatted_performance_metrics.append('{}={:.2f}'.format(key_name, latency_cutoff_ratio))
+                formatted_performance_metrics.append('{}={:.2f}'.format(key_name, calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_latency_ns", "target_latency_ns")))
             elif key_name == "cutoff_ratio_ttft":
-                formatted_performance_metrics.append('{}={:.2f}'.format(key_name, latency_cutoff_ratio_ttft))
+                formatted_performance_metrics.append('{}={:.2f}'.format(key_name, calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_first_token_latency_ns", "ttft_latency_ns")))
             elif key_name == "cutoff_ratio_tpot":
-                formatted_performance_metrics.append('{}={:.2f}'.format(key_name, latency_cutoff_ratio_tpot))
+                formatted_performance_metrics.append('{}={:.2f}'.format(key_name, calc_latency_cutoff_ratio(parsed_summary, "99.00_percentile_time_to_output_token_ns", "tpot_latency_ns")))
             elif key_name == "early_stopping_overhead":
                 formatted_performance_metrics.append('{}={:.2f}{}'.format(key_name, early_stopping_overhead, "%"))
             else:

--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -65,14 +65,104 @@ def beautify_summary(parsed_summary):
     
     return beautified_summary
 
+def get_latency_classic(parsed_summary):
+
+    scenario = parsed_summary["Scenario"]
+    if scenario == "Server":
+        if "target_latency_ns" in parsed_summary.keys():
+            latency_classic_ms = '{:.2f}'.format(parsed_summary["99.00_percentile_latency_ns"]*0.000001)
+        else:
+            latency_classic_ms = "None"
+
+    return latency_classic_ms
+
+def get_latency_ttft(parsed_summary):
+
+    scenario = parsed_summary["Scenario"]
+    if scenario == "Server":
+        if "ttft_latency_ns" in parsed_summary.keys():
+            latency_ttft_ms = '{:.2f}'.format(parsed_summary["99.00_percentile_first_token_latency_ns"]*0.000001)
+        else:
+            latency_ttft_ms = "None"
+
+    return latency_ttft_ms
+
+def get_latency_tpot(parsed_summary):
+
+    scenario = parsed_summary["Scenario"]
+    if scenario == "Server":
+        if "tpot_latency_ns" in parsed_summary.keys():
+            latency_tpot_ms = '{:.2f}'.format(parsed_summary["99.00_percentile_time_to_output_token_ns"]*0.000001)
+        else:
+            latency_tpot_ms = "None"
+
+    return latency_tpot_ms
+
+def get_target_latency_classic(parsed_summary):
+
+    scenario = parsed_summary["Scenario"]
+    if scenario == "Server":
+        if "target_latency_ns" in parsed_summary.keys():
+            target_latency_classic_ms = '{:.2f}'.format(parsed_summary["target_latency_ns"]*0.000001)
+        else:
+            target_latency_classic_ms = "None"
+
+    return target_latency_classic_ms
+
+def get_target_latency_ttft(parsed_summary):
+
+    scenario = parsed_summary["Scenario"]
+    if scenario == "Server":
+        if "ttft_latency_ns" in parsed_summary.keys():
+            target_latency_ttft_ms = '{:.2f}'.format(parsed_summary["ttft_latency_ns"]*0.000001)
+        else:
+            target_latency_ttft_ms = "None"
+
+    return target_latency_ttft_ms
+
+def get_target_latency_tpot(parsed_summary):
+
+    scenario = parsed_summary["Scenario"]
+    if scenario == "Server":
+        if "tpot_latency_ns" in parsed_summary.keys():
+            target_latency_tpot_ms = '{:.2f}'.format(parsed_summary["tpot_latency_ns"]*0.000001)
+        else:
+            target_latency_tpot_ms = "None"
+
+    return target_latency_tpot_ms
 
 def calc_latency_cutoff_ratio(parsed_summary):
     
     scenario = parsed_summary["Scenario"]
-
     if scenario == "Server":
-        return parsed_summary["99.00_percentile_latency_ns"]/parsed_summary["target_latency_ns"]
+        if "target_latency_ns" in parsed_summary.keys():
+            latency_cutoff_ratio = parsed_summary["99.00_percentile_latency_ns"]/parsed_summary["target_latency_ns"]
+        else:
+            latency_cutoff_ratio = "None"
 
+    return latency_cutoff_ratio
+
+def calc_latency_cutoff_ratio_ttft(parsed_summary):
+
+    scenario = parsed_summary["Scenario"]
+    if scenario == "Server":
+        if "ttft_latency_ns" in parsed_summary.keys():
+            latency_cutoff_ratio_ttft = parsed_summary["99.00_percentile_first_token_latency_ns"]/parsed_summary["ttft_latency_ns"]
+        else:
+            latency_cutoff_ratio_ttft = "None"
+
+    return latency_cutoff_ratio_ttft
+
+def calc_latency_cutoff_ratio_tpot(parsed_summary):
+
+    scenario = parsed_summary["Scenario"]
+    if scenario == "Server":
+        if "tpot_latency_ns" in parsed_summary.keys():
+            latency_cutoff_ratio_tpot = parsed_summary["99.00_percentile_time_to_output_token_ns"]/parsed_summary["tpot_latency_ns"]
+        else:
+            latency_cutoff_ratio_tpot = "None"
+
+    return latency_cutoff_ratio_tpot
 
 def calc_early_stopping_overhead(parsed_summary):
 
@@ -99,16 +189,48 @@ def parse_performance(beautified_summary, latency_cutoff_ratio, early_stopping_o
     for key_name in performance_metrics:
 
         if raw:
-            if key_name == "latency_cutoff_ratio":
+            if  key_name == "99.00_percentile_latency_ms":
+                formatted_performance_metrics.append(latency_classic_ms)
+            elif key_name == "99.00_percentile_ttft_ms":
+                formatted_performance_metrics.append(latency_ttft_ms)
+            elif key_name == "99.00_percentile_tpot_ms":
+                formatted_performance_metrics.append(latency_tpot_ms)
+            elif key_name == "target_latency_ms":
+                formatted_performance_metrics.append(target_latency_classic_ms)
+            elif key_name == "target_ttft_ms":
+                formatted_performance_metrics.append(target_latency_ttft_ms)
+            elif key_name == "target_tpot_ms":
+                formatted_performance_metrics.append(target_latency_tpot_ms)
+            elif key_name == "latency_cutoff_ratio":
                 formatted_performance_metrics.append(latency_cutoff_ratio)
+            elif key_name == "cutoff_ratio_ttft":
+                formatted_performance_metrics.append(latency_cutoff_ratio_ttft)
+            elif key_name == "cutoff_ratio_tpot":
+                formatted_performance_metrics.append(latency_cutoff_ratio_tpot)
             elif key_name == "early_stopping_overhead":
                 formatted_performance_metrics.append(early_stopping_overhead)
             else:
                 formatted_performance_metrics.append(beautified_summary[key_name])
                
         else: #no need for multiplier, formatting, units in scenario_performance_map - the beautify_summary function does all of this already 
-            if key_name == "latency_cutoff_ratio":
+            if  key_name == "99.00_percentile_latency_ms":
+                formatted_performance_metrics.append('{}={}'.format(key_name, latency_classic_ms))
+            elif key_name == "99.00_percentile_ttft_ms":
+                formatted_performance_metrics.append('{}={}'.format(key_name, latency_ttft_ms))
+            elif key_name == "99.00_percentile_tpot_ms":
+                formatted_performance_metrics.append('{}={}'.format(key_name, latency_tpot_ms))
+            elif key_name == "target_latency_ms":
+                formatted_performance_metrics.append('{}={}'.format(key_name, target_latency_classic_ms))
+            elif key_name == "target_ttft_ms":
+                formatted_performance_metrics.append('{}={}'.format(key_name, target_latency_ttft_ms))
+            elif key_name == "target_tpot_ms":
+                formatted_performance_metrics.append('{}={}'.format(key_name, target_latency_tpot_ms))
+            elif key_name == "latency_cutoff_ratio":
                 formatted_performance_metrics.append('{}={:.2f}'.format(key_name, latency_cutoff_ratio))
+            elif key_name == "cutoff_ratio_ttft":
+                formatted_performance_metrics.append('{}={}'.format(key_name, latency_cutoff_ratio_ttft))
+            elif key_name == "cutoff_ratio_tpot":
+                formatted_performance_metrics.append('{}={}'.format(key_name, latency_cutoff_ratio_tpot))
             elif key_name == "early_stopping_overhead":
                 formatted_performance_metrics.append('{}={:.2f}{}'.format(key_name, early_stopping_overhead, "%"))
             else:

--- a/base_loadgen_experiment/code_axs.py
+++ b/base_loadgen_experiment/code_axs.py
@@ -65,104 +65,57 @@ def beautify_summary(parsed_summary):
     
     return beautified_summary
 
-def get_latency_classic(parsed_summary):
+def calc_latency_cutoff_ratio(parsed_summary, latency, target_latency):
 
     scenario = parsed_summary["Scenario"]
     if scenario == "Server":
-        if "target_latency_ns" in parsed_summary.keys():
-            latency_classic_ms = '{:.2f}'.format(parsed_summary["99.00_percentile_latency_ns"]*0.000001)
-        else:
-            latency_classic_ms = "None"
+        if target_latency in parsed_summary.keys():
+            return parsed_summary[latency]/parsed_summary[target_latency]
 
-    return latency_classic_ms
+latency_classic = "99.00_percentile_latency_ns"
+latency_ttft = "99.00_percentile_first_token_latency_ns"
+latency_tpot = "99.00_percentile_time_to_output_token_ns"
 
-def get_latency_ttft(parsed_summary):
+target_latency_classic = "target_latency_ns"
+target_latency_ttft = "ttft_latency_ns"
+target_latency_tpot = "tpot_latency_ns"
 
-    scenario = parsed_summary["Scenario"]
-    if scenario == "Server":
-        if "ttft_latency_ns" in parsed_summary.keys():
-            latency_ttft_ms = '{:.2f}'.format(parsed_summary["99.00_percentile_first_token_latency_ns"]*0.000001)
-        else:
-            latency_ttft_ms = "None"
+latency_cutoff_ratio = calc_latency_cutoff_ratio(parsed_summary, latency_classic, target_latency_classic)
+latency_cutoff_ratio_ttft = calc_latency_cutoff_ratio(parsed_summary, latency_ttft, target_latency_ttft)
+latency_cutoff_ratio_tpot = calc_latency_cutoff_ratio(parsed_summary, latency_tpot, target_latency_tpot)
 
-    return latency_ttft_ms
-
-def get_latency_tpot(parsed_summary):
-
-    scenario = parsed_summary["Scenario"]
-    if scenario == "Server":
-        if "tpot_latency_ns" in parsed_summary.keys():
-            latency_tpot_ms = '{:.2f}'.format(parsed_summary["99.00_percentile_time_to_output_token_ns"]*0.000001)
-        else:
-            latency_tpot_ms = "None"
-
-    return latency_tpot_ms
-
-def get_target_latency_classic(parsed_summary):
-
-    scenario = parsed_summary["Scenario"]
-    if scenario == "Server":
-        if "target_latency_ns" in parsed_summary.keys():
-            target_latency_classic_ms = '{:.2f}'.format(parsed_summary["target_latency_ns"]*0.000001)
-        else:
-            target_latency_classic_ms = "None"
-
-    return target_latency_classic_ms
-
-def get_target_latency_ttft(parsed_summary):
-
-    scenario = parsed_summary["Scenario"]
-    if scenario == "Server":
-        if "ttft_latency_ns" in parsed_summary.keys():
-            target_latency_ttft_ms = '{:.2f}'.format(parsed_summary["ttft_latency_ns"]*0.000001)
-        else:
-            target_latency_ttft_ms = "None"
-
-    return target_latency_ttft_ms
-
-def get_target_latency_tpot(parsed_summary):
-
-    scenario = parsed_summary["Scenario"]
-    if scenario == "Server":
-        if "tpot_latency_ns" in parsed_summary.keys():
-            target_latency_tpot_ms = '{:.2f}'.format(parsed_summary["tpot_latency_ns"]*0.000001)
-        else:
-            target_latency_tpot_ms = "None"
-
-    return target_latency_tpot_ms
-
-def calc_latency_cutoff_ratio(parsed_summary):
+# def calc_latency_cutoff_ratio(parsed_summary):
     
-    scenario = parsed_summary["Scenario"]
-    if scenario == "Server":
-        if "target_latency_ns" in parsed_summary.keys():
-            latency_cutoff_ratio = parsed_summary["99.00_percentile_latency_ns"]/parsed_summary["target_latency_ns"]
-        else:
-            latency_cutoff_ratio = "None"
+#     scenario = parsed_summary["Scenario"]
+#     if scenario == "Server":
+#         if "target_latency_ns" in parsed_summary.keys():
+#             latency_cutoff_ratio = parsed_summary["99.00_percentile_latency_ns"]/parsed_summary["target_latency_ns"]
+#         else:
+#             latency_cutoff_ratio = "None"
 
-    return latency_cutoff_ratio
+#     return latency_cutoff_ratio
 
-def calc_latency_cutoff_ratio_ttft(parsed_summary):
+# def calc_latency_cutoff_ratio_ttft(parsed_summary):
 
-    scenario = parsed_summary["Scenario"]
-    if scenario == "Server":
-        if "ttft_latency_ns" in parsed_summary.keys():
-            latency_cutoff_ratio_ttft = parsed_summary["99.00_percentile_first_token_latency_ns"]/parsed_summary["ttft_latency_ns"]
-        else:
-            latency_cutoff_ratio_ttft = "None"
+#     scenario = parsed_summary["Scenario"]
+#     if scenario == "Server":
+#         if "ttft_latency_ns" in parsed_summary.keys():
+#             latency_cutoff_ratio_ttft = parsed_summary["99.00_percentile_first_token_latency_ns"]/parsed_summary["ttft_latency_ns"]
+#         else:
+#             latency_cutoff_ratio_ttft = "None"
 
-    return latency_cutoff_ratio_ttft
+#     return latency_cutoff_ratio_ttft
 
-def calc_latency_cutoff_ratio_tpot(parsed_summary):
+# def calc_latency_cutoff_ratio_tpot(parsed_summary):
 
-    scenario = parsed_summary["Scenario"]
-    if scenario == "Server":
-        if "tpot_latency_ns" in parsed_summary.keys():
-            latency_cutoff_ratio_tpot = parsed_summary["99.00_percentile_time_to_output_token_ns"]/parsed_summary["tpot_latency_ns"]
-        else:
-            latency_cutoff_ratio_tpot = "None"
+#     scenario = parsed_summary["Scenario"]
+#     if scenario == "Server":
+#         if "tpot_latency_ns" in parsed_summary.keys():
+#             latency_cutoff_ratio_tpot = parsed_summary["99.00_percentile_time_to_output_token_ns"]/parsed_summary["tpot_latency_ns"]
+#         else:
+#             latency_cutoff_ratio_tpot = "None"
 
-    return latency_cutoff_ratio_tpot
+#     return latency_cutoff_ratio_tpot
 
 def calc_early_stopping_overhead(parsed_summary):
 
@@ -189,19 +142,7 @@ def parse_performance(beautified_summary, latency_cutoff_ratio, early_stopping_o
     for key_name in performance_metrics:
 
         if raw:
-            if  key_name == "99.00_percentile_latency_ms":
-                formatted_performance_metrics.append(latency_classic_ms)
-            elif key_name == "99.00_percentile_ttft_ms":
-                formatted_performance_metrics.append(latency_ttft_ms)
-            elif key_name == "99.00_percentile_tpot_ms":
-                formatted_performance_metrics.append(latency_tpot_ms)
-            elif key_name == "target_latency_ms":
-                formatted_performance_metrics.append(target_latency_classic_ms)
-            elif key_name == "target_ttft_ms":
-                formatted_performance_metrics.append(target_latency_ttft_ms)
-            elif key_name == "target_tpot_ms":
-                formatted_performance_metrics.append(target_latency_tpot_ms)
-            elif key_name == "latency_cutoff_ratio":
+            if key_name == "latency_cutoff_ratio":
                 formatted_performance_metrics.append(latency_cutoff_ratio)
             elif key_name == "cutoff_ratio_ttft":
                 formatted_performance_metrics.append(latency_cutoff_ratio_ttft)
@@ -213,19 +154,7 @@ def parse_performance(beautified_summary, latency_cutoff_ratio, early_stopping_o
                 formatted_performance_metrics.append(beautified_summary[key_name])
                
         else: #no need for multiplier, formatting, units in scenario_performance_map - the beautify_summary function does all of this already 
-            if  key_name == "99.00_percentile_latency_ms":
-                formatted_performance_metrics.append('{}={}'.format(key_name, latency_classic_ms))
-            elif key_name == "99.00_percentile_ttft_ms":
-                formatted_performance_metrics.append('{}={}'.format(key_name, latency_ttft_ms))
-            elif key_name == "99.00_percentile_tpot_ms":
-                formatted_performance_metrics.append('{}={}'.format(key_name, latency_tpot_ms))
-            elif key_name == "target_latency_ms":
-                formatted_performance_metrics.append('{}={}'.format(key_name, target_latency_classic_ms))
-            elif key_name == "target_ttft_ms":
-                formatted_performance_metrics.append('{}={}'.format(key_name, target_latency_ttft_ms))
-            elif key_name == "target_tpot_ms":
-                formatted_performance_metrics.append('{}={}'.format(key_name, target_latency_tpot_ms))
-            elif key_name == "latency_cutoff_ratio":
+            if key_name == "latency_cutoff_ratio":
                 formatted_performance_metrics.append('{}={:.2f}'.format(key_name, latency_cutoff_ratio))
             elif key_name == "cutoff_ratio_ttft":
                 formatted_performance_metrics.append('{}={}'.format(key_name, latency_cutoff_ratio_ttft))

--- a/base_loadgen_experiment/data_axs.json
+++ b/base_loadgen_experiment/data_axs.json
@@ -13,7 +13,23 @@
 
     "beautified_summary": [ "^^", "beautify_summary" ],
 
+    "99.00_percentile_latency_ms": [ "^^", "get_latency_classic" ],
+
+    "target_latency_ms": [ "^^", "get_target_latency_classic" ],
+
     "latency_cutoff_ratio": [ "^^", "calc_latency_cutoff_ratio" ],
+
+    "99.00_percentile_ttft_ms": [ "^^", "get_latency_ttft" ],
+
+    "target_ttft_ms": [ "^^", "get_target_latency_ttft" ],
+
+    "cutoff_ratio_ttft": [ "^^", "calc_latency_cutoff_ratio_ttft" ],
+
+    "99.00_percentile_tpot_ms": [ "^^", "get_latency_tpot" ],
+
+    "target_tpot_ms": [ "^^", "get_target_latency_tpot" ],
+
+    "cutoff_ratio_tpot": [ "^^", "calc_latency_cutoff_ratio_tpot" ],
 
     "early_stopping_overhead": [ "^^", "calc_early_stopping_overhead" ],
 
@@ -31,8 +47,8 @@
             "INVALID":  ["99th_percentile_latency", "_Early_stopping_99th_percentile_estimate", "early_stopping_overhead"]
         },
         "Server":       {
-            "VALID":    ["target_qps", "99.00_percentile_latency", "target_latency", "latency_cutoff_ratio", "Completed_samples_per_second"],
-            "INVALID":  ["target_qps", "99.00_percentile_latency", "target_latency", "latency_cutoff_ratio", "Completed_samples_per_second"]
+            "VALID":    ["target_qps", "99.00_percentile_latency_ms", "target_latency_ms", "latency_cutoff_ratio", "99.00_percentile_ttft_ms", "target_ttft_ms", "cutoff_ratio_ttft", "99.00_percentile_tpot_ms", "target_tpot_ms", "cutoff_ratio_tpot", "Completed_samples_per_second"],
+            "INVALID":  ["target_qps", "99.00_percentile_latency_ms", "target_latency_ms", "latency_cutoff_ratio", "99.00_percentile_ttft_ms", "target_ttft_ms", "cutoff_ratio_ttft", "99.00_percentile_tpot_ms", "target_tpot_ms", "cutoff_ratio_tpot", "Completed_samples_per_second"]
         }
     },
 

--- a/base_loadgen_experiment/data_axs.json
+++ b/base_loadgen_experiment/data_axs.json
@@ -16,22 +16,10 @@
     "early_stopping_overhead": [ "^^", "calc_early_stopping_overhead" ],
 
     "scenario_performance_map": {
-        "Offline":      {
-            "VALID":    ["Samples_per_second", "target_qps"],
-            "INVALID":  ["Samples_per_second", "target_qps"]
-        },
-        "SingleStream": {
-            "VALID":    ["90th_percentile_latency", "_Early_stopping_90th_percentile_estimate", "early_stopping_overhead"],
-            "INVALID":  ["90th_percentile_latency", "_Early_stopping_90th_percentile_estimate", "early_stopping_overhead"]
-        },
-        "MultiStream":  {
-            "VALID":    ["99th_percentile_latency", "_Early_stopping_99th_percentile_estimate", "early_stopping_overhead"],
-            "INVALID":  ["99th_percentile_latency", "_Early_stopping_99th_percentile_estimate", "early_stopping_overhead"]
-        },
-        "Server":       {
-            "VALID":    ["target_qps", "99.00_percentile_latency", "target_latency", "latency_cutoff_ratio", "99.00_percentile_ttft", "target_ttft", "cutoff_ratio_ttft", "99.00_percentile_tpot", "target_tpot", "cutoff_ratio_tpot", "Completed_samples_per_second"],
-            "INVALID":  ["target_qps", "99.00_percentile_latency", "target_latency", "latency_cutoff_ratio", "99.00_percentile_ttft", "target_ttft", "cutoff_ratio_ttft", "99.00_percentile_tpot", "target_tpot", "cutoff_ratio_tpot", "Completed_samples_per_second"]
-        }
+        "Offline":      ["Samples_per_second", "target_qps"],
+        "SingleStream": ["90th_percentile_latency", "_Early_stopping_90th_percentile_estimate", "early_stopping_overhead"],
+        "MultiStream":  ["99th_percentile_latency", "_Early_stopping_99th_percentile_estimate", "early_stopping_overhead"],
+        "Server":       ["target_qps", "99.00_percentile_latency", "target_latency", "latency_cutoff_ratio", "99.00_percentile_first_token_latency", "ttft_latency", "cutoff_ratio_ttft", "99.00_percentile_time_to_output_token", "tpot_latency", "cutoff_ratio_tpot", "Completed_samples_per_second"]
     },
 
     "performance": ["^^", "parse_performance"], 

--- a/base_loadgen_experiment/data_axs.json
+++ b/base_loadgen_experiment/data_axs.json
@@ -13,24 +13,6 @@
 
     "beautified_summary": [ "^^", "beautify_summary" ],
 
-    "99.00_percentile_latency_ms": [ "^^", "get_latency_classic" ],
-
-    "target_latency_ms": [ "^^", "get_target_latency_classic" ],
-
-    "latency_cutoff_ratio": [ "^^", "calc_latency_cutoff_ratio" ],
-
-    "99.00_percentile_ttft_ms": [ "^^", "get_latency_ttft" ],
-
-    "target_ttft_ms": [ "^^", "get_target_latency_ttft" ],
-
-    "cutoff_ratio_ttft": [ "^^", "calc_latency_cutoff_ratio_ttft" ],
-
-    "99.00_percentile_tpot_ms": [ "^^", "get_latency_tpot" ],
-
-    "target_tpot_ms": [ "^^", "get_target_latency_tpot" ],
-
-    "cutoff_ratio_tpot": [ "^^", "calc_latency_cutoff_ratio_tpot" ],
-
     "early_stopping_overhead": [ "^^", "calc_early_stopping_overhead" ],
 
     "scenario_performance_map": {
@@ -47,8 +29,8 @@
             "INVALID":  ["99th_percentile_latency", "_Early_stopping_99th_percentile_estimate", "early_stopping_overhead"]
         },
         "Server":       {
-            "VALID":    ["target_qps", "99.00_percentile_latency_ms", "target_latency_ms", "latency_cutoff_ratio", "99.00_percentile_ttft_ms", "target_ttft_ms", "cutoff_ratio_ttft", "99.00_percentile_tpot_ms", "target_tpot_ms", "cutoff_ratio_tpot", "Completed_samples_per_second"],
-            "INVALID":  ["target_qps", "99.00_percentile_latency_ms", "target_latency_ms", "latency_cutoff_ratio", "99.00_percentile_ttft_ms", "target_ttft_ms", "cutoff_ratio_ttft", "99.00_percentile_tpot_ms", "target_tpot_ms", "cutoff_ratio_tpot", "Completed_samples_per_second"]
+            "VALID":    ["target_qps", "99.00_percentile_latency", "target_latency", "latency_cutoff_ratio", "99.00_percentile_ttft", "target_ttft", "cutoff_ratio_ttft", "99.00_percentile_tpot", "target_tpot", "cutoff_ratio_tpot", "Completed_samples_per_second"],
+            "INVALID":  ["target_qps", "99.00_percentile_latency", "target_latency", "latency_cutoff_ratio", "99.00_percentile_ttft", "target_ttft", "cutoff_ratio_ttft", "99.00_percentile_tpot", "target_tpot", "cutoff_ratio_tpot", "Completed_samples_per_second"]
         }
     },
 


### PR DESCRIPTION
Updated `, get performance` output to work with LLM benchmarks. 
LLM Server benchmarks contain new latency metrics: Time To First Token (TTFT) and Time To Output Token (TPOT) that are now also collected.
The classic benchmarks output looks like before:
```
['INVALID', 'target_qps=541000', '99.00_percentile_latency=16.381 milliseconds', 'target_latency=15.000 milliseconds', 'latency_cutoff_ratio=1.09', 'Completed_samples_per_second=541169.81']
```
The LLM benchmarks output now looks like this:
```
['VALID', 'target_qps=6', '99.00_percentile_latency=26.794 seconds', '99.00_percentile_first_token_latency=0.181 seconds', 'ttft_latency=2.000 seconds', 'cutoff_ratio_ttft=0.09', '99.00_percentile_time_to_output_token=50.743 milliseconds', 'tpot_latency=0.200 seconds', 'cutoff_ratio_tpot=0.25', 'Completed_samples_per_second=5.98']
```